### PR TITLE
Fix when formatting fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 
 # python compiled files
 *.pyc
+
+# ignore PyCharm files
+.idea/*

--- a/logstash_formatter/__init__.py
+++ b/logstash_formatter/__init__.py
@@ -82,8 +82,9 @@ class LogstashFormatter(logging.Formatter):
             msg = msg.format(**fields)
         except (KeyError, IndexError):
             pass
-        except Exception:
-            msg = msg  # temporary hack to avoid crash if formatting fails
+        except:
+            # in case we can not format the msg properly we log it as is instead of crashing
+            msg = msg
 
         if 'msg' in fields:
             fields.pop('msg')
@@ -153,6 +154,9 @@ class LogstashFormatterV1(LogstashFormatter):
                 msg = msg.format(**fields)
             except (KeyError, IndexError):
                 pass
+            except:
+                # in case we can not format the msg properly we log it as is instead of crashing
+                msg = msg
             fields['message'] = msg
 
         if 'exc_info' in fields:

--- a/logstash_formatter/__init__.py
+++ b/logstash_formatter/__init__.py
@@ -82,6 +82,8 @@ class LogstashFormatter(logging.Formatter):
             msg = msg.format(**fields)
         except (KeyError, IndexError):
             pass
+        except Exception:
+            msg = msg  # temporary hack to avoid crash if formatting fails
 
         if 'msg' in fields:
             fields.pop('msg')

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,19 @@
 import codecs
+import unittest
+
 from setuptools import setup, find_packages
 from os import path
 
 def read(*parts):
     return codecs.open(path.join(path.dirname(__file__), *parts),
                        encoding="utf-8").read()
+
+
+def tests_suite():
+    test_loader = unittest.TestLoader()
+    test_suite = test_loader.discover('tests', pattern='test_*.py')
+    return test_suite
+
 
 setup(name='logstash_formatter',
       version='0.5.16',
@@ -24,4 +33,5 @@ setup(name='logstash_formatter',
           'Programming Language :: Python',
           'Programming Language :: Python :: 3'
       ],
-      zip_safe=False)
+      zip_safe=False,
+      test_suite='setup.tests_suite')

--- a/tests/test_log_message_positional_placeholder.py
+++ b/tests/test_log_message_positional_placeholder.py
@@ -1,5 +1,5 @@
 import logging
-from io import StringIO
+from six import StringIO
 import unittest
 
 import logstash_formatter
@@ -8,12 +8,13 @@ import logstash_formatter
 class LogMessagePositionalPlaceholderTest(unittest.TestCase):
 
     def setUp(self):
-        self.stream = StringIO.StringIO()
+        self.stream = StringIO()
         handler = logging.StreamHandler(self.stream)
         handler.setFormatter(logstash_formatter.LogstashFormatterV1())
         handler.setLevel(logging.DEBUG)
         self.log = logging.getLogger('test')
         self.log.addHandler(handler)
+        self.log.setLevel(logging.DEBUG)
 
     def assertLogMessage(self, msg):
         self.assertTrue(
@@ -37,4 +38,8 @@ def make_method(msg):
 
 
 for name, msg in test_msgs.items():
+    name = 'test_{}'.format(name)
     setattr(LogMessagePositionalPlaceholderTest, name, make_method(msg))
+
+
+print(LogMessagePositionalPlaceholderTest)

--- a/tests/test_log_message_positional_placeholder.py
+++ b/tests/test_log_message_positional_placeholder.py
@@ -24,7 +24,8 @@ class LogMessagePositionalPlaceholderTest(unittest.TestCase):
 test_msgs = {
     'normal_log_message': 'foo',
     'implicit_positional_placeholder': '{}',
-    'explicit_positional_placeholder': '{0}'
+    'explicit_positional_placeholder': '{0}',
+    'message_with_invalid_formatting': '{'
 }
 
 
@@ -40,6 +41,3 @@ def make_method(msg):
 for name, msg in test_msgs.items():
     name = 'test_{}'.format(name)
     setattr(LogMessagePositionalPlaceholderTest, name, make_method(msg))
-
-
-print(LogMessagePositionalPlaceholderTest)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py27,py33,py34,py35
+[testenv]
+changedir=tests
+commands=discover
+deps=
+    discover
+    six


### PR DESCRIPTION
The tests were broken but I made them run again.
Also if you have broken message e.g. `"msg {"` the formatter fails to format it and crashes. I think that a better approach is to show the broken message instead.