### PR TITLE
Add ValueError exception check to msg.format

### DIFF
--- a/logstash_formatter/__init__.py
+++ b/logstash_formatter/__init__.py
@@ -80,7 +80,7 @@ class LogstashFormatter(logging.Formatter):
 
         try:
             msg = msg.format(**fields)
-        except (KeyError, IndexError):
+        except (KeyError, IndexError, ValueError):
             pass
         except:
             # in case we can not format the msg properly we log it as is instead of crashing


### PR DESCRIPTION
Messages with unpaired braces will fail with `ValueError: unmatched '{' in format` message if ValueError isn't caught